### PR TITLE
add new images URL

### DIFF
--- a/config.json
+++ b/config.json
@@ -13,7 +13,7 @@
   "imageExclusionUrls": ["amazon"],
 
   "//imageUrls": "URL substrings to match against/download images from.",
-	"imageUrls": ["blogspot", "flickr"],
+	"imageUrls": ["blogspot", "flickr", "blogger.googleusercontent.com"],
 
   "//imageRelativeUrl": "http://your.image.domain/",
   "imageRelativeUrl": "https://weblog-files.200ok.com.au/"


### PR DESCRIPTION
Google silently moved all images. And if you export your blog again it will have the new URLs.

This adds the new host into the config.